### PR TITLE
Remove height from sound-player-overlay so that text can wrap cleanly

### DIFF
--- a/src/Mint-L/cinnamon/cinnamon-dark.css
+++ b/src/Mint-L/cinnamon/cinnamon-dark.css
@@ -1442,7 +1442,6 @@ StScrollBar {
 
 .sound-player-overlay {
   width: 290px;
-  height: 70px;
   padding: 15px;
   spacing: 0.5em;
   background: rgba(47, 47, 47, 0.9);

--- a/src/Mint-L/cinnamon/cinnamon.css
+++ b/src/Mint-L/cinnamon/cinnamon.css
@@ -1442,7 +1442,6 @@ StScrollBar {
 
 .sound-player-overlay {
   width: 290px;
-  height: 70px;
   padding: 15px;
   spacing: 0.5em;
   background: rgba(240, 240, 240, 0.9);

--- a/src/Mint-L/cinnamon/sass/_common.scss
+++ b/src/Mint-L/cinnamon/sass/_common.scss
@@ -1852,7 +1852,6 @@ StScrollBar {
 
   &-overlay {
     width: 290px;
-    height: 70px;
     padding: 15px;
     spacing: 0.5em;
     background: transparentize($bg_color, 0.1);


### PR DESCRIPTION
Same as https://github.com/linuxmint/mint-themes/pull/453 but for Mint L theme.

Fixes #13