### PR TITLE
Cinnamon: window-list applet set fixed notification badge font size

### DIFF
--- a/src/Mint-L/cinnamon/cinnamon-dark.css
+++ b/src/Mint-L/cinnamon/cinnamon-dark.css
@@ -1356,6 +1356,9 @@ StScrollBar {
   border-radius: 99px;
   background-color: #4a4a4a; }
 
+.grouped-window-list-notifications-badge-label {
+  font-size: 12px; }
+
 .grouped-window-list-button-label {
   padding-left: 4px; }
 

--- a/src/Mint-L/cinnamon/cinnamon.css
+++ b/src/Mint-L/cinnamon/cinnamon.css
@@ -1356,6 +1356,9 @@ StScrollBar {
   border-radius: 99px;
   background-color: #4a4a4a; }
 
+.grouped-window-list-notifications-badge-label {
+  font-size: 12px; }
+
 .grouped-window-list-button-label {
   padding-left: 4px; }
 

--- a/src/Mint-L/cinnamon/sass/_common.scss
+++ b/src/Mint-L/cinnamon/sass/_common.scss
@@ -1804,6 +1804,10 @@ $base_padding: 7px;
     background-color: $tooltip_fg_color;
   }
 
+  &-notifications-badge-label {
+    font-size: 12px;
+  }
+
   &-button-label {
     padding-left: 4px;
   }


### PR DESCRIPTION
This is needed to set a fixed notification badge font size in the window-list applet as the selector `window-list-item-box.bottom StLabel{}` in Mint-L, having a higher specificity, overrides the `grouped-window-list-notification-badge-label{}` selector in the default cinnamon theme.

Fixes notification badges being too big in window-list applet with user font scaling.