### PR TITLE
fixed scrollbar overwriting window borders on wayland

### DIFF
--- a/src/Mint-L/gtk-3.0/gtk-dark.css
+++ b/src/Mint-L/gtk-3.0/gtk-dark.css
@@ -1744,12 +1744,13 @@ notebook {
       padding: 2px; }
 
 scrollbar {
-  border: 1px solid transparent;
   background-color: #3d3d3d;
   transition: 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   * {
     -GtkScrollbar-has-backward-stepper: false;
     -GtkScrollbar-has-forward-stepper: false; }
+  terminal-screen-container scrollbar {
+    border: 1px solid transparent; }
   scrollbar.top {
     border-bottom: 1px solid #292929; }
   scrollbar.bottom {

--- a/src/Mint-L/gtk-3.0/gtk-dark.css
+++ b/src/Mint-L/gtk-3.0/gtk-dark.css
@@ -1744,6 +1744,7 @@ notebook {
       padding: 2px; }
 
 scrollbar {
+  border: 1px solid transparent;
   background-color: #3d3d3d;
   transition: 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   * {

--- a/src/Mint-L/gtk-3.0/gtk-darker.css
+++ b/src/Mint-L/gtk-3.0/gtk-darker.css
@@ -1743,6 +1743,7 @@ notebook {
       padding: 2px; }
 
 scrollbar {
+  border: 1px solid transparent;
   background-color: #fcfcfc;
   transition: 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   * {

--- a/src/Mint-L/gtk-3.0/gtk-darker.css
+++ b/src/Mint-L/gtk-3.0/gtk-darker.css
@@ -1743,12 +1743,13 @@ notebook {
       padding: 2px; }
 
 scrollbar {
-  border: 1px solid transparent;
   background-color: #fcfcfc;
   transition: 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   * {
     -GtkScrollbar-has-backward-stepper: false;
     -GtkScrollbar-has-forward-stepper: false; }
+  terminal-screen-container scrollbar {
+    border: 1px solid transparent; }
   scrollbar.top {
     border-bottom: 1px solid #BDBDBD; }
   scrollbar.bottom {

--- a/src/Mint-L/gtk-3.0/gtk.css
+++ b/src/Mint-L/gtk-3.0/gtk.css
@@ -1749,6 +1749,7 @@ notebook {
       padding: 2px; }
 
 scrollbar {
+  border: 1px solid transparent;
   background-color: #fcfcfc;
   transition: 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   * {

--- a/src/Mint-L/gtk-3.0/gtk.css
+++ b/src/Mint-L/gtk-3.0/gtk.css
@@ -1749,12 +1749,13 @@ notebook {
       padding: 2px; }
 
 scrollbar {
-  border: 1px solid transparent;
   background-color: #fcfcfc;
   transition: 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   * {
     -GtkScrollbar-has-backward-stepper: false;
     -GtkScrollbar-has-forward-stepper: false; }
+  terminal-screen-container scrollbar {
+    border: 1px solid transparent; }
   scrollbar.top {
     border-bottom: 1px solid #BDBDBD; }
   scrollbar.bottom {

--- a/src/Mint-L/gtk-3.0/sass/_common.scss
+++ b/src/Mint-L/gtk-3.0/sass/_common.scss
@@ -1867,6 +1867,7 @@ scrollbar {
 
   $_slider_min_length: 40px;
 
+  border: 1px solid transparent;
   background-color: $_scrollbar_bg_color;
   transition: 300ms $ease-out-quad;
 

--- a/src/Mint-L/gtk-3.0/sass/_common.scss
+++ b/src/Mint-L/gtk-3.0/sass/_common.scss
@@ -1867,7 +1867,7 @@ scrollbar {
 
   $_slider_min_length: 40px;
 
-  border: 1px solid transparent;
+  terminal-screen-container & { border: 1px solid transparent; }
   background-color: $_scrollbar_bg_color;
   transition: 300ms $ease-out-quad;
 


### PR DESCRIPTION
the scrollbar overwrites the window border on wayland
creating a 1px transparent border around the scrollbar fixes it

<img width="40%" height="40%" alt="Screenshot from 2026-02-27 23-36-09" src="https://github.com/user-attachments/assets/b0a40ab4-82c3-4e25-b81b-1f7cae73d75e" /> <img width="40%" height="40%" alt="Screenshot from 2026-02-27 23-36-39" src="https://github.com/user-attachments/assets/b1f8be4c-529a-45cb-9318-3aab39c22a06" />

mint-y has the same issue, i also made a pr there with the same change

i opened a wayland issue on this a while ago, fixed it for my theme and closed the issue but forgot to fix it for mint-y and mint-l https://github.com/linuxmint/wayland/issues/156